### PR TITLE
History tweaks

### DIFF
--- a/tobar-segais-webapp/src/main/webapp/js/tobar-segais.js
+++ b/tobar-segais-webapp/src/main/webapp/js/tobar-segais.js
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+String.prototype.endsWith = function(str) { // http://stackoverflow.com/questions/280634/endswith-in-javascript
+    var lastIndex = this.lastIndexOf(str);
+    return lastIndex != -1 && lastIndex + str.length == this.length;
+};
 var TobairSegais = {
     toRawUri:function (uri) {
         var i = uri.indexOf('#');
@@ -35,6 +39,28 @@ var TobairSegais = {
             $(this).click(TobairSegais.clickSupport);
         });
     },
+    scroll:function (url) {
+        // scroll content
+        var i = url.indexOf('#');
+        if (i != -1) {
+            // XXX clumsy but cannot get $('[name="ElementNameHere"]') to work
+            // note: does not work for generated IDs like d0e4161 after redeploy unless you force a browser refresh
+            var nl = document.getElementsByName(url.substring(i + 1));
+            for (var j = 0; j < nl.length; j++) {
+                nl.item(j).scrollIntoView();
+            }
+        } else {
+            $('#content').each(function (i, e) {
+                e.scrollIntoView();
+            });
+        }
+        // scroll index
+        var nl = $('a').filter(function() {return this.href.endsWith(url)});
+        if (nl.length > 0) {
+            // XXX better to do this only if not already visible
+            nl[0].scrollIntoView();
+        }
+    },
     loadContent:function (url) {
         if (/^https?:\/\//.test(url)) {
             return true;
@@ -45,6 +71,8 @@ var TobairSegais = {
                 var i = url.indexOf('#');
                 if (i != -1) {
                     window.location.href = url.substring(i);
+                } else {
+                    TobairSegais.scroll(url);
                 }
                 document.title = $("#contents-nav a[href='"+(i == -1 ? url : url.substring(0,i))+"']").text();
             });
@@ -78,6 +106,7 @@ window.onpopstate = function (event) {
     if (event != null && event.state != null) {
         $('#content').load(TobairSegais.toRawUri(event.state.url), function () {
             TobairSegais.addClickSupport("#content");
+            TobairSegais.scroll(event.state.url);
         });
     }
 };


### PR DESCRIPTION
Probably needs some more testing, but these changes on Chrome at least make the app behave more naturally when moving back and forth in history: anchors are used only where needed, and you are scrolled to what you want to see.
